### PR TITLE
Removing monitoring plugin

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/enterpriseplugins/PluginImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/enterpriseplugins/PluginImpl.java
@@ -184,7 +184,6 @@ public class PluginImpl extends Plugin {
             require("matrix-project","1.5"),
             require("maven-plugin","2.10"),
             require("mercurial","1.52"),
-            require("monitoring","1.56.0"),
             require("nectar-rbac","4.15"),
             require("nectar-vmware","4.3.4"),
             require("node-iterator-api","1.5"),


### PR DESCRIPTION
It appears that `monitoring 1.57.0` assumes that it is running in a Servlet 3.x container, and breaks Jenkins usage when it is run on 2.x. (Not yet filed.) Currently the HA proxy WAR, which users of this metaplugin are likely to try, bundles 2.x. Since this plugin is not really needed anyway, do not try to install it. (Note that we are only _requiring_ 1.56.0 but the metaplugin always picks the latest version actually offered on the UC.)

@reviewbybees (ref. CJP-3441)
